### PR TITLE
Fix absolute urls in profile view

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,8 +2,8 @@ import DefaultAvatar from '@/assets/navbar/DefaultIcon.svg';
 
 export default {
   getPuzzleMiddleThumbnail(nid: string) {
-    // return `https://s3.amazonaws.com/eterna/puzzle_mid_thumbnails/thumbnail${nid}.png`;
-    return `https://renderv2-prod-renderv2bucket86ab868d-1aq5x6e32xf92.s3.amazonaws.com/puzzle_mid_thumbnails/thumbnail${nid}.svg`;
+    return `https://s3.amazonaws.com/eterna/puzzle_mid_thumbnails/thumbnail${nid}.png`;
+    // return `https://renderv2-prod-renderv2bucket86ab868d-1aq5x6e32xf92.s3.amazonaws.com/puzzle_mid_thumbnails/thumbnail${nid}.svg`;
   },
   getPuzzleCloudThumbnail(nid: string) {
     return `https://s3.amazonaws.com/eterna/puzzle_cloud_thumbnails/thumbnail${nid}.png`;

--- a/src/views/landing/ExperiencedPlayerHome/components/BannerSlide.vue
+++ b/src/views/landing/ExperiencedPlayerHome/components/BannerSlide.vue
@@ -74,6 +74,14 @@
     object-fit: cover;
   }
 
+  .enter-lab {
+    font-weight: bold;
+    font-size: 20px;
+    padding: 9px 12px;
+    margin-bottom: 10px;
+    text-shadow: none;
+  }
+
   h1 {
     font-size: 20px;
   }

--- a/src/views/landing/ExperiencedPlayerHome/components/PuzzleSlide.vue
+++ b/src/views/landing/ExperiencedPlayerHome/components/PuzzleSlide.vue
@@ -85,6 +85,7 @@
     font-size: 20px;
     padding: 9px 12px;
     margin-bottom: 10px;
+    text-shadow: none;
   }
 
   h1,

--- a/src/views/players/EditProfile/components/EditPlayerHeaderImage.vue
+++ b/src/views/players/EditProfile/components/EditPlayerHeaderImage.vue
@@ -22,6 +22,7 @@
 
 <script lang="ts">
   import { Component, Vue, Mixins, Prop } from 'vue-property-decorator';
+  import Utils from '@/utils/utils';
   import { UserData } from '@/types/common-types';
   import { DEFAULT_PLAYER_PICTURE } from '@/utils/constants';
 
@@ -34,7 +35,7 @@
     }
 
     get picture() {
-      return this.user.picture && `${process.env.VUE_APP_API_BASE_URL}/${this.user.picture}`;
+      return Utils.getAvatar(this.user.picture);
     }
   }
 </script>

--- a/src/views/players/EditProfile/components/EditPlayerHeaderImage.vue
+++ b/src/views/players/EditProfile/components/EditPlayerHeaderImage.vue
@@ -23,8 +23,6 @@
 <script lang="ts">
   import { Component, Vue, Mixins, Prop } from 'vue-property-decorator';
   import Utils from '@/utils/utils';
-  import { UserData } from '@/types/common-types';
-  import { DEFAULT_PLAYER_PICTURE } from '@/utils/constants';
 
   @Component({
     components: {},

--- a/src/views/players/PlayerView/components/PlayerHeaderImage.vue
+++ b/src/views/players/PlayerView/components/PlayerHeaderImage.vue
@@ -17,23 +17,14 @@
 <script lang="ts">
   import { Component, Vue, Mixins, Prop } from 'vue-property-decorator';
   import { UserData } from '@/types/common-types';
-  import { DEFAULT_PLAYER_PICTURE } from '@/utils/constants';
+  import Utils from '@/utils/utils';
 
   @Component({
     components: {},
   })
   export default class PlayerHeaderImage extends Vue {
     get picture() {
-      const playerImage = this.user.picture;
-      const lowercaseUrl = playerImage.toLowerCase();
-      let fullUrl = playerImage;
-      if (lowercaseUrl.length === 0) {
-        fullUrl = DEFAULT_PLAYER_PICTURE;
-      } else if (!(lowercaseUrl.startsWith('http://') || lowercaseUrl.startsWith('https://'))) {
-        fullUrl = `${process.env.VUE_APP_API_BASE_URL}/${playerImage}`;
-      }
-      console.log(fullUrl);
-      return fullUrl;
+      return Utils.getAvatar(this.user.picture);
     }
 
     @Prop() user!: UserData;

--- a/src/views/players/PlayerView/components/PlayerHeaderImage.vue
+++ b/src/views/players/PlayerView/components/PlayerHeaderImage.vue
@@ -24,7 +24,16 @@
   })
   export default class PlayerHeaderImage extends Vue {
     get picture() {
-      return this.user.picture && `${process.env.VUE_APP_API_BASE_URL}/${this.user.picture}`;
+      const playerImage = this.user.picture;
+      const lowercaseUrl = playerImage.toLowerCase();
+      let fullUrl = playerImage;
+      if (lowercaseUrl.length === 0) {
+        fullUrl = DEFAULT_PLAYER_PICTURE;
+      } else if (!(lowercaseUrl.startsWith('http://') || lowercaseUrl.startsWith('https://'))) {
+        fullUrl = `${process.env.VUE_APP_API_BASE_URL}/${playerImage}`;
+      }
+      console.log(fullUrl);
+      return fullUrl;
     }
 
     @Prop() user!: UserData;


### PR DESCRIPTION
- When Image is not specified, it will render default image (both for profile view & edit)
- If the URL is relative, it will prefix with image URL
- If the URL is absolute (such as FB images) it will leave intact.