### PR TITLE
CH-1024 Fixing absolute URL renders in Profile Edit

### DIFF
--- a/src/views/players/EditProfile/components/EditPlayerHeaderImage.vue
+++ b/src/views/players/EditProfile/components/EditPlayerHeaderImage.vue
@@ -22,6 +22,7 @@
 
 <script lang="ts">
   import { Component, Vue, Mixins, Prop } from 'vue-property-decorator';
+  import Utils from '@/utils/utils';
   import { UserData } from '@/types/common-types';
   import { DEFAULT_PLAYER_PICTURE } from '@/utils/constants';
 
@@ -34,7 +35,7 @@
     }
 
     get picture() {
-      return this.user.picture && `${process.env.VUE_APP_API_BASE_URL}/${this.user.picture}`;
+      return Utils.getAvatar(this.user.picture);
     }
   }
 </script>

--- a/src/views/players/EditProfile/components/EditPlayerHeaderImage.vue
+++ b/src/views/players/EditProfile/components/EditPlayerHeaderImage.vue
@@ -23,8 +23,6 @@
 <script lang="ts">
   import { Component, Vue, Mixins, Prop } from 'vue-property-decorator';
   import Utils from '@/utils/utils';
-  import { UserData } from '@/types/common-types';
-  import { DEFAULT_PLAYER_PICTURE } from '@/utils/constants';
 
   @Component({
     components: {},

--- a/src/views/players/PlayerView/components/PlayerHeaderImage.vue
+++ b/src/views/players/PlayerView/components/PlayerHeaderImage.vue
@@ -17,23 +17,14 @@
 <script lang="ts">
   import { Component, Vue, Mixins, Prop } from 'vue-property-decorator';
   import { UserData } from '@/types/common-types';
-  import { DEFAULT_PLAYER_PICTURE } from '@/utils/constants';
+  import Utils from '@/utils/utils';
 
   @Component({
     components: {},
   })
   export default class PlayerHeaderImage extends Vue {
     get picture() {
-      const playerImage = this.user.picture;
-      const lowercaseUrl = playerImage.toLowerCase();
-      let fullUrl = playerImage;
-      if (lowercaseUrl.length === 0) {
-        fullUrl = DEFAULT_PLAYER_PICTURE;
-      } else if (!(lowercaseUrl.startsWith('http://') || lowercaseUrl.startsWith('https://'))) {
-        fullUrl = `${process.env.VUE_APP_API_BASE_URL}/${playerImage}`;
-      }
-      console.log(fullUrl);
-      return fullUrl;
+      return Utils.getAvatar(this.user.picture);
     }
 
     @Prop() user!: UserData;

--- a/src/views/players/PlayerView/components/PlayerHeaderImage.vue
+++ b/src/views/players/PlayerView/components/PlayerHeaderImage.vue
@@ -24,7 +24,16 @@
   })
   export default class PlayerHeaderImage extends Vue {
     get picture() {
-      return this.user.picture && `${process.env.VUE_APP_API_BASE_URL}/${this.user.picture}`;
+      const playerImage = this.user.picture;
+      const lowercaseUrl = playerImage.toLowerCase();
+      let fullUrl = playerImage;
+      if (lowercaseUrl.length === 0) {
+        fullUrl = DEFAULT_PLAYER_PICTURE;
+      } else if (!(lowercaseUrl.startsWith('http://') || lowercaseUrl.startsWith('https://'))) {
+        fullUrl = `${process.env.VUE_APP_API_BASE_URL}/${playerImage}`;
+      }
+      console.log(fullUrl);
+      return fullUrl;
     }
 
     @Prop() user!: UserData;


### PR DESCRIPTION
- When Image is not specified, it will render default image for profile view + edit
- If the URL is relative, it will prefix with image URL
- If the URL is absolute (such as FB images) it will leave intact.
- Using existing `getAvatar` method from `Utils`.