### PR TITLE
Implemented a solved indicator under Puzzle Info on the Puzzle page

### DIFF
--- a/src/types/common-types.ts
+++ b/src/types/common-types.ts
@@ -211,6 +211,7 @@ export interface PuzzleResponse {
   puzzle: Puzzle;
   nid: string;
   comments: CommentItem[];
+  cleared?: ClearedPuzzle[];
 }
 
 export interface NewsArticle {

--- a/src/views/puzzles/PuzzleView/PuzzleView.vue
+++ b/src/views/puzzles/PuzzleView/PuzzleView.vue
@@ -60,6 +60,9 @@
           <li v-if="puzzle.created">
             <img src="@/assets/calendar.svg" class="icon" />{{ puzzle.created }}
           </li>
+          <li v-if="clearedThisPuzzle">
+            <img src="@/assets/noun_check.svg" class="icon" />Cleared
+          </li>
         </ul>
       </SidebarPanel>
       <!-- <TagsPanel :tags="['#SRP', '#easy']" :isInSidebar="isInSidebar" /> -->
@@ -80,7 +83,7 @@
   import Preloader from '@/components/PageLayout/Preloader.vue';
   import Comments from '@/components/PageLayout/Comments.vue';
   import FetchMixin from '@/mixins/FetchMixin';
-  import { PuzzleResponse, Puzzle, CommentItem } from '@/types/common-types';
+  import { PuzzleResponse, Puzzle, CommentItem, ClearedPuzzle } from '@/types/common-types';
 
   @Component({
     components: {
@@ -100,6 +103,8 @@
 
     comments: CommentItem[] = [];
 
+    clearedPuzzles: ClearedPuzzle[] = [];
+
     async fetch() {
       const res = (
         await this.$http.get(`/get/?type=puzzle&nid=${this.$route.params.id}&script=-1`, {
@@ -112,10 +117,15 @@
       this.puzzle = res.puzzle;
       this.nid = res.nid;
       this.comments = res.comments;
+      this.clearedPuzzles = res.cleared || [];
     }
 
     get madeByPlayer() {
       return this.puzzle && this.puzzle['made-by-player'] !== '0';
+    }
+
+    get clearedThisPuzzle() {
+      return this.puzzle && this.clearedPuzzles.some(puzzle => this.nid === puzzle.id);
     }
 
     get imageURL() {


### PR DESCRIPTION
Added an indicator for whether the user has completed a given puzzle.
There is a cleared indicator under puzzle info on the puzzle page similar to the one on the puzzle explore page.

Resolves: #229 

**Puzzle Explorer:**
![Puzzle Explore View](https://user-images.githubusercontent.com/33671251/115935380-0eae0280-a461-11eb-9e5a-d9ea5075f145.PNG)

**Puzzle Page - Solved Puzzle:**
![Solved Puzzle](https://user-images.githubusercontent.com/33671251/115935427-22f1ff80-a461-11eb-9ba1-f63205f358ca.PNG)

**Puzzle Page - Unsolved Puzzle:**
![Unsolved Puzzle](https://user-images.githubusercontent.com/33671251/115935430-24bbc300-a461-11eb-8c97-3892811419b0.PNG)