### PR TITLE
Fixes title wrap for Eterna page

### DIFF
--- a/src/components/PageLayout/EternaPage.vue
+++ b/src/components/PageLayout/EternaPage.vue
@@ -95,6 +95,7 @@
     justify-content: space-between;
     align-items: center;
     font-size: 33.75px;
+    max-width: 74.5%;
   }
   .sidebar {
     font-size: 13.125px;


### PR DESCRIPTION
Titles for Eterna pages now properly wrap at the end of the main column instead of continuing over the sidebar.

Resolves: #228 

EG, https://eternagame.org/news/10174790
![title-wrap](https://user-images.githubusercontent.com/33671251/115938359-5dab6600-a468-11eb-9098-eeed6c122d62.PNG)