### PR TITLE
Fixed Group Notifications (Broadcasts and Comments)

### DIFF
--- a/src/types/common-types.ts
+++ b/src/types/common-types.ts
@@ -380,5 +380,5 @@ export function isPMNotiItem(notification: NotificationItem): notification is Pr
 }
 
 export function isCommentNotiItem(notification: NotificationItem): notification is CommentNotificationItem {
-  return isNotiNotiItem(notification) && ( notification.message[0].type === NotificationMessageType.COMMENT);
+  return isDirectedNotificationItem(notification) && ( notification.message[0].type === NotificationMessageType.COMMENT);
 }

--- a/src/views/feed/ActivityFeed/components/CommentMessageItem.vue
+++ b/src/views/feed/ActivityFeed/components/CommentMessageItem.vue
@@ -45,7 +45,7 @@
           return `/news/${id}`;
         case 'group':
         case 'eterna_group':
-          return `${process.env.VUE_APP_API_BASE_URL}/group/${id}/`;
+          return `${process.env.VUE_APP_API_BASE_URL}/web/group/${id}/`;
         case 'solution': {
           const pid = (this.message.content.node as any).puzzle_id;
           return `${process.env.VUE_APP_API_BASE_URL}/game/browse/${pid}/?filter1=Id&filter1_arg1=${id}&filter1_arg2=${id}`;

--- a/src/views/feed/ActivityFeed/components/GroupMessageItem.vue
+++ b/src/views/feed/ActivityFeed/components/GroupMessageItem.vue
@@ -7,10 +7,7 @@
       :avatar="avatar"
     >
       <template>
-          {{ notification.target2_name + ' ' }} {{ isInvite ? $t('activity-feed:invite') : $t('activity-feed:broadcast') + ' ' }}
-          <router-link :to="`/groups/${nid}`">
-              {{ title }}
-          </router-link>
+          {{ notification.target2_name + ' ' }} {{ isInvite ? $t('activity-feed:invite') : $t('activity-feed:broadcast') + ' ' }}{{ title }}
       </template>
     </MessageItem>
   </div>

--- a/src/views/feed/ActivityFeed/components/GroupMessageItem.vue
+++ b/src/views/feed/ActivityFeed/components/GroupMessageItem.vue
@@ -7,7 +7,7 @@
       :avatar="avatar"
     >
       <template>
-          {{ notification.target2_name + ' ' }} {{ isInvite ? $t('activity-feed:invite') : $t('activity-feed:broadcast') + ' ' }}{{ title }}
+          {{ notification.target2_name + ' ' }} {{ isInvite ? $t('activity-feed:invite') + ' ' : $t('activity-feed:broadcast') + ' ' }}{{ title }}
       </template>
     </MessageItem>
   </div>


### PR DESCRIPTION
Fixes a handful of issues related to group notifications.

Resolves: #110 

1. Group Broadcasts no longer contain a link
    - The nid referenced by the link points to the notification id rather than the group id
    - Wrong id resulted in the link pointing to a non-existent/incorrect group
    - Full fix would require a patch on the DB so temporarily just removed the link
2. Group Comments now display the proper text
    - Originally group comments displayed as group broadcasts
    - Fixed an incorrect conditional in common-types.ts
3. Group Comments link to the group is now correct
    - Originally group comments linked to a legacy part of the site that no longer exists
    - Link now properly points to the appropriate group

**Updated Group Notifications:**
![Group Notifications](https://user-images.githubusercontent.com/33671251/115950674-bac80b80-a4aa-11eb-8549-5c0ce6b4458a.PNG)