### PR TITLE
Added link to player's profile in all appropriate notifications

### DIFF
--- a/src/views/feed/ActivityFeed/components/CommentMessageItem.vue
+++ b/src/views/feed/ActivityFeed/components/CommentMessageItem.vue
@@ -7,7 +7,10 @@
       :message="message.content.body"
     >
       <template>
-          {{ notification.target2_name + ' ' }} {{ $t('activity-feed:commented-on') + ' ' }}
+          <router-link :to="`/players/` + message.sender">
+            {{ notification.target2_name + ' ' }} 
+          </router-link>
+          {{ $t('activity-feed:commented-on') + ' ' }}
           <a :href="link">
               {{ message.content.node.title }}
           </a>

--- a/src/views/feed/ActivityFeed/components/GroupMessageItem.vue
+++ b/src/views/feed/ActivityFeed/components/GroupMessageItem.vue
@@ -7,7 +7,10 @@
       :avatar="avatar"
     >
       <template>
-          {{ notification.target2_name + ' ' }} {{ isInvite ? $t('activity-feed:invite') : $t('activity-feed:broadcast') + ' ' }}
+          <router-link :to="`/players/` + message.sender">
+            {{ notification.target2_name + ' ' }} 
+          </router-link>
+          {{ isInvite ? $t('activity-feed:invite') : $t('activity-feed:broadcast') + ' ' }}
           <router-link :to="`/groups/${nid}`">
               {{ title }}
           </router-link>

--- a/src/views/feed/ActivityFeed/components/PrivateMessageItem.vue
+++ b/src/views/feed/ActivityFeed/components/PrivateMessageItem.vue
@@ -5,7 +5,14 @@
     :avatar="avatar"
     :message="message.content"
   >
-    {{ senderName }} > {{ recieverName }}:
+    <router-link :to="`/players/` + senderID">
+      {{ senderName }} 
+    </router-link>
+    > 
+    <router-link :to="`/players/` + receiverID">
+      {{ receiverName }}
+    </router-link>
+    :
   </MessageItem>
 </template>
 <script lang="ts">
@@ -22,13 +29,25 @@
     
     @Prop({ required: true }) readonly message!: PrivateNotificationMessage;
 
+    get senderID() {
+      return this.message.sender === this.notification.target_uid
+        ? this.notification.target_uid
+        : this.notification.target2_uid;
+    }
+
+    get receiverID() {
+      return this.message.sender === this.notification.target_uid
+        ? this.notification.target2_uid
+        : this.notification.target_uid;
+    }
+
     get senderName() {
       return this.message.sender === this.notification.target_uid
         ? this.notification.target_name
         : this.notification.target2_name;
     }
 
-    get recieverName() {
+    get receiverName() {
       return this.message.sender === this.notification.target_uid
         ? this.notification.target2_name
         : this.notification.target_name;


### PR DESCRIPTION
Added a link to the player's profile wherever a player's name shows up in a notification

Handles player profile links for the following:
    - Group broadcasts
    - Comments of all types (news, puzzles, group, etc.)
    - Direct private messages and replies to them

Resolves: #223 
Combined with #236, should fix all issues related to notifications that remain. 

**New notification view after #236 and this patch:**
![Notifications Player Profile Links](https://user-images.githubusercontent.com/33671251/115953283-86f3e280-a4b8-11eb-8018-611a617bc1a1.PNG)