### PR TITLE
Groups Tab in Player Profile

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -96,7 +96,6 @@
   "player-view:featured-achievement-details": "View Badges",
   "player-view:global-rank": "Global Rank:",
   "player-view:about-me": "About Me",
-
   "player-view:synthesized-rnas": "Synthesized RNAs",
   "player-view:rna-title": "RNA Title",
   "player-view:score": "Score",
@@ -104,6 +103,7 @@
   "player-view:created-puzzles": "Created Puzzles",
   "player-view:latest-played-puzzles": "Latest Played Puzzles",
   "player-view:cleared-puzzles": "Cleared Puzzles",
+  "player-view:joined-groups": "Groups",
   "news-view:comments": "Comments",
   "news-view:enter-comments": "Enter your comments here.",
   "edit-profile:custom-section-remove": "Remove",
@@ -227,6 +227,7 @@
   "side-panel-options:latest": "Latest Activity",
   "side-panel-options:created": "Created Puzzles",
   "side-panel-options:cleared": "Cleared Puzzles",
+  "side-panel-options:groups": "Groups",
   "side-panel-options:about": "About",
   "side-panel-options:about-eterna": "About Eterna",
   "side-panel-options:publications": "Publications",

--- a/src/views/players/PlayerView/PlayerView.vue
+++ b/src/views/players/PlayerView/PlayerView.vue
@@ -103,6 +103,25 @@
             </tr>
           </template>
         </PlayerTable>
+
+        <PlayerTable
+          v-if="$route.query.tab_type == 'groups'"
+          :title="$t('player-view:joined-groups')"
+          :entries="joinedGroups"
+        >
+          <template v-slot:theader>
+            <tr class="table-primary">
+              <th scope="col">{{ $t('player-view:joined-groups') }}</th>
+            </tr>
+          </template>
+          <template v-slot:trow="slotProps">
+            <tr>
+              <td class="puzzle-link">
+                <a :href="`/web/group/${slotProps.item.group_nid}/`">{{ slotProps.item.group_title }}</a>
+              </td>
+            </tr>
+          </template>
+        </PlayerTable>
       </div>
     </div>
     <div v-else>
@@ -135,7 +154,8 @@
     ClearedPuzzle,
     CreatedPuzzle,
     SynthesizedDesign,
-    ProfileAchievement
+    ProfileAchievement,
+    ProfileGroup
   } from '@/types/common-types';
   import PlayerHeader from './components/PlayerHeader.vue';
   import PlayerAboutMe from './components/PlayerAboutMe.vue';
@@ -163,6 +183,7 @@
       { value: 'created', text: 'side-panel-options:created' },
       { value: 'latest', text: 'side-panel-options:latest' },
       { value: 'cleared', text: 'side-panel-options:cleared' },
+      { value: 'groups', text: 'side-panel-options:groups' }
     ];
 
     user: UserData | null = null;
@@ -179,10 +200,12 @@
 
     achievements: {[name: string]: ProfileAchievement} = {};
 
+    joinedGroups: ProfileGroup[] = [];
+
     async fetch() {
       const ROUTE = `/get/?type=user&uid=${this.$route.params.uid}`;
-      // Achievements are provided when no tab_type is specified.
-      const tab_type = this.$route.query.tab_type === 'achievements' ? 'about' : this.$route.query.tab_type;
+      // Achievements and Groups are provided when no tab_type is specified.
+      const tab_type = (this.$route.query.tab_type === ('achievements') || this.$route.query.tab_type === ('groups')) ? 'about' : this.$route.query.tab_type;
       const res = (await this.$http.get(ROUTE, { params: { tab_type } })).data.data as UserResponse;
       this.user = res.user;
       this.follow = res.follow;
@@ -191,6 +214,7 @@
       this.clearedPuzzles = res.cleared_puzzles || [];
       this.synthesized = res.synthesized || [];
       this.achievements = res.achievements || {};
+      this.joinedGroups = res.my_group || [];
     }
   }
 </script>


### PR DESCRIPTION
Added a groups tab to the player profile which shows shows a table of all the groups a player is current in (does not include pending groups)

Resolves: #217 

![Profile Groups Display](https://user-images.githubusercontent.com/33671251/115974651-23a39800-a52c-11eb-8d1e-37535514bbb8.PNG)