### PR TITLE
Edit About Page

### DIFF
--- a/src/views/about/About.vue
+++ b/src/views/about/About.vue
@@ -103,7 +103,7 @@
                   ></iframe>
                 </div>
                 <h1 class="challenges__heading">
-                  <a href="/labs/10027854">
+                  <a :href="`/challenges/${challenge.nid}`">
                     {{ challenge.title }}
                   </a>
                 </h1>


### PR DESCRIPTION
- The anchor tag link associated with each challenge presented on the About Page was not generated using each challenge's id.