### PR TITLE
order about page publications by timestamp field

### DIFF
--- a/src/types/common-types.ts
+++ b/src/types/common-types.ts
@@ -130,6 +130,7 @@ export interface Publication {
   title: string;
   journal: string;
   pub_date: string;
+  timestamp: number;
   link: string;
   has_player_authors: boolean;
   authors: string;

--- a/src/views/about/About.vue
+++ b/src/views/about/About.vue
@@ -494,7 +494,7 @@
         ...publications.researcherpubslist,
         ...publications.playerpubslist
       ]
-      .sort((a, b) => parseInt(b.pub_date, 10) - parseInt(a.pub_date, 10))
+      .sort((a, b) => b.timestamp - a.timestamp)
       .slice(0, 3);
     }
     


### PR DESCRIPTION
* Use new timestamp field (integer) introduced to a publication object to sort publications by publish date. `pub_date` which had previously been used to determine ordering was a formatted date string (e.g. "May 2020") so was not suitable for this role. 