### PR TITLE
Add calendar highlights and fix calendar ranges

### DIFF
--- a/src/components/Sidebar/CalendarPanel.vue
+++ b/src/components/Sidebar/CalendarPanel.vue
@@ -1,6 +1,6 @@
 <template>
-  <SidebarPanel v-if="notableDates" :isInSidebar="isInSidebar" header="calendar" headerIcon="@/assets/calendar.svg">
-    <vc-date-picker is-range v-model="dates" color="yellow" :attributes="notableDates.selectAttribute" @update:from-page="changePage" is-dark is-inline />
+  <SidebarPanel :isInSidebar="isInSidebar" header="calendar" headerIcon="@/assets/calendar.svg">
+    <vc-date-picker is-range v-model="dates" color="yellow" :attributes="highlightDates" @update:from-page="changePage" is-dark is-inline />
   </SidebarPanel>
 </template>
 
@@ -25,17 +25,20 @@
   })
   export default class CalendarPanel extends mixins(SidebarPanelMixin) {
 
-    @Prop({required: false}) readonly notableDates!: any;
+    @Prop({required: false}) readonly notableDates!: {selectAttribute: { dot: string; dates: string; }[]} ;
 
     private dates: {
       start?: Date;
       end?: Date;
     } = {};
 
-    private defaultDate!: DateItem;
 
-    private changePage(shownMonth = this.defaultDate){
+    private changePage(shownMonth : DateItem){
       this.$emit('page-update', shownMonth);
+    }
+
+    get highlightDates(){
+      return this.notableDates? this.notableDates.selectAttribute: [];
     }
 
     mounted() {

--- a/src/components/Sidebar/CalendarPanel.vue
+++ b/src/components/Sidebar/CalendarPanel.vue
@@ -1,6 +1,6 @@
 <template>
-  <SidebarPanel :isInSidebar="isInSidebar" header="calendar" headerIcon="@/assets/calendar.svg">
-    <vc-date-picker is-range v-model="dates" color="yellow" :attributes="selectAttribute" is-dark is-inline @update:from-page="fetch"/>
+  <SidebarPanel v-if="notableDates" :isInSidebar="isInSidebar" header="calendar" headerIcon="@/assets/calendar.svg">
+    <vc-date-picker is-range v-model="dates" color="yellow" :attributes="notableDates.selectAttribute" @update:from-page="changePage" is-dark is-inline />
   </SidebarPanel>
 </template>
 
@@ -9,7 +9,7 @@
   import { mixins } from 'vue-class-component';
   import SidebarPanel from '@/components/Sidebar/SidebarPanel.vue';
   import SidebarPanelMixin from '@/mixins/SidebarPanel';
-  import { NewsItem, DateItem } from '@/types/common-types';
+  import { DateItem } from '@/types/common-types';
   
   // @ts-ignore
   import VCalendar from 'v-calendar';
@@ -18,22 +18,25 @@
     componentPrefix: 'vc',
   });
 
-  const INITIAL_NUMBER = 18;
-
-  const ROUTE = '/get/?type=newsandblogslist';
-
   @Component({
     components: {
       SidebarPanel,
     },
   })
   export default class CalendarPanel extends mixins(SidebarPanelMixin) {
+
+    @Prop({required: false}) readonly notableDates!: any;
+
     private dates: {
       start?: Date;
       end?: Date;
     } = {};
 
     private defaultDate!: DateItem;
+
+    private changePage(shownMonth = this.defaultDate){
+      this.$emit('page-update', shownMonth);
+    }
 
     mounted() {
       const { start_date, end_date } = this.$route.query;
@@ -46,50 +49,6 @@
         };
       }
     }
-
-
-    async fetch(shownMonth = this.defaultDate){
-      
-      let i = 0;
-      // go from first day of month to first day of next month
-
-      // means data is not already loaded, string matching
-      if(!this.$data.months.includes(`${shownMonth.month}${shownMonth.year}`)){
-
-        this.$data.months.push(`${shownMonth.month}${shownMonth.year}`);
-
-        const res = (
-          await this.$http.get(ROUTE, {
-              params: {
-                size: INITIAL_NUMBER,
-                from_created: new Date(shownMonth.year, shownMonth.month - 1, 1).getTime() / 1000,
-                to_created: new Date(shownMonth.year, shownMonth.month, 1).getTime() / 1000,
-                }
-            })
-          ).data.data.entries as NewsItem[];
-
-        // not sure about adjusting for timezones, is setting the locale to en us okay?
-        // it's only being used to parse dates, which is already being printed in UTC Time
-
-        for(; i < res.length; i += 1){
-
-          this.$data.selectAttribute.push({
-            dot:'blue',
-            dates: new Date(Number(res[i].timestamp) * 1000).toLocaleString('en-US', {timeZone: 'UTC'}),
-          });
-        }
-      }
-
-    }
-
-    data(){
-      return {
-        selectAttribute:[],
-        months:[]
-      };
-
-    }
-
 
     @Watch('dates')
     onSearch(event: KeyboardEvent) {

--- a/src/components/Sidebar/CalendarPanel.vue
+++ b/src/components/Sidebar/CalendarPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <SidebarPanel :isInSidebar="isInSidebar" header="calendar" headerIcon="@/assets/calendar.svg">
-    <vc-date-picker is-range v-model="dates" color="yellow" is-dark is-inline />
+    <vc-date-picker is-range v-model="dates" color="yellow" :attributes="selectAttribute" is-dark is-inline @update:from-page="fetch"/>
   </SidebarPanel>
 </template>
 
@@ -9,12 +9,18 @@
   import { mixins } from 'vue-class-component';
   import SidebarPanel from '@/components/Sidebar/SidebarPanel.vue';
   import SidebarPanelMixin from '@/mixins/SidebarPanel';
+  import { NewsItem, DateItem } from '@/types/common-types';
+  
   // @ts-ignore
   import VCalendar from 'v-calendar';
 
   Vue.use(VCalendar, {
     componentPrefix: 'vc',
   });
+
+  const INITIAL_NUMBER = 18;
+
+  const ROUTE = '/get/?type=newsandblogslist';
 
   @Component({
     components: {
@@ -27,15 +33,63 @@
       end?: Date;
     } = {};
 
+    private defaultDate!: DateItem;
+
     mounted() {
       const { start_date, end_date } = this.$route.query;
 
-      if (start_date && end_date)
+      if (start_date && end_date){
+
         this.dates = {
           start: new Date(start_date as string),
           end: new Date(end_date as string),
         };
+      }
     }
+
+
+    async fetch(shownMonth = this.defaultDate){
+      
+      let i = 0;
+      // go from first day of month to first day of next month
+
+      // means data is not already loaded, string matching
+      if(!this.$data.months.includes(`${shownMonth.month}${shownMonth.year}`)){
+
+        this.$data.months.push(`${shownMonth.month}${shownMonth.year}`);
+
+        const res = (
+          await this.$http.get(ROUTE, {
+              params: {
+                size: INITIAL_NUMBER,
+                from_created: new Date(shownMonth.year, shownMonth.month - 1, 1).getTime() / 1000,
+                to_created: new Date(shownMonth.year, shownMonth.month, 1).getTime() / 1000,
+                }
+            })
+          ).data.data.entries as NewsItem[];
+
+        // not sure about adjusting for timezones, is setting the locale to en us okay?
+        // it's only being used to parse dates, which is already being printed in UTC Time
+
+        for(; i < res.length; i += 1){
+
+          this.$data.selectAttribute.push({
+            dot:'blue',
+            dates: new Date(Number(res[i].timestamp) * 1000).toLocaleString('en-US', {timeZone: 'UTC'}),
+          });
+        }
+      }
+
+    }
+
+    data(){
+      return {
+        selectAttribute:[],
+        months:[]
+      };
+
+    }
+
 
     @Watch('dates')
     onSearch(event: KeyboardEvent) {

--- a/src/types/common-types.ts
+++ b/src/types/common-types.ts
@@ -359,6 +359,11 @@ export interface BlogItem {
   comments: CommentItem[];
 }
 
+export interface DateItem{
+  month: number;
+  year: number;
+}
+
 export interface AboutMediaItem {
   link: string;
   title: string;

--- a/src/views/news/NewsExplore/NewsExplore.vue
+++ b/src/views/news/NewsExplore/NewsExplore.vue
@@ -18,7 +18,7 @@
         replace
         :isInSidebar="isInSidebar"
       />
-      <CalendarPanel :isInSidebar="isInSidebar" />
+      <CalendarPanel  v-if="isInSidebar" @page-update="monthFetch" :notableDates="calendarItems" :isInSidebar="isInSidebar"/>
       <!-- <TagsPanel :tags="tags" :isInSidebar="isInSidebar" /> -->
     </template>
     <template #mobileSearchbar>
@@ -39,7 +39,7 @@
   import Pagination from '@/components/PageLayout/Pagination.vue';
   import CalendarPanel from '@/components/Sidebar/CalendarPanel.vue';
   import Preloader from '@/components/PageLayout/Preloader.vue';
-  import { NewsItem, BlogItem } from '@/types/common-types';
+  import { NewsItem, BlogItem, DateItem } from '@/types/common-types';
   import FetchMixin from '@/mixins/FetchMixin';
   import NewsCard from './components/NewsCard.vue';
 
@@ -60,6 +60,7 @@
       Preloader,
     },
   })
+
   export default class NewsExplore extends Mixins(FetchMixin) {
     private tags: string[] = ['#Ribosome', '#XOR', '#MS2', '#tRNA', '#mRNA'];
 
@@ -71,6 +72,43 @@
 
     private newsItems: (NewsItem|BlogItem)[] = [];
 
+    private calendarItems:{} = {};
+
+    private defaultDate!: DateItem;
+
+    async monthFetch(monthData = this.defaultDate){
+
+      let i = 0;
+      const totalDates = [];
+
+      const res = (
+          await this.$http.get(ROUTE, {
+              params: {
+                size: INITIAL_NUMBER,
+                from_created: new Date(monthData.year, monthData.month - 1, 1).getTime() / 1000,
+                to_created: new Date(monthData.year, monthData.month, 1).getTime() / 1000,
+                }
+            })
+          ).data.data.entries as NewsItem[];
+      
+      // Timezone in UTC, calendar dates parsing is incorrect
+      
+      for(; i < res.length; i += 1){
+
+        totalDates.push(
+          {
+            dot: 'blue',
+            dates: new Date(Number(res[i].timestamp) * 1000).toLocaleString('en-US', {timeZone: 'UTC'}),
+          }
+        );
+      }
+
+
+      this.calendarItems = {
+        selectAttribute: totalDates,
+        };
+    }
+
     async fetch() {
       const { sort, end_date, start_date, size, search } = this.$route.query;
       
@@ -80,14 +118,11 @@
           params: {
             search,
             size: size || INITIAL_NUMBER,
-            from_created: start_date && new Date(String(start_date).replace(/-/g, '/')).getTime() / 1000,
-            to_created: end_date && (new Date(String(end_date).replace(/-/g, '/')).getTime() / 1000),
+            from_created: start_date && new Date(start_date.toString().replace(/-/g, '/')).getTime() / 1000,
+            to_created: end_date && (new Date(end_date.toString().replace(/-/g, '/')).getTime() / 1000),
           },
         })
       ).data.data.entries as NewsItem[];
-      
-
-      // incosistent behaviour with different date ranges
 
       // TODO https://github.com/eternagame/eternagame.org/issues/157 move filtering to backend
       switch (sort) {

--- a/src/views/news/NewsExplore/NewsExplore.vue
+++ b/src/views/news/NewsExplore/NewsExplore.vue
@@ -73,17 +73,22 @@
 
     async fetch() {
       const { sort, end_date, start_date, size, search } = this.$route.query;
+      
 
       const res = (
         await this.$http.get(ROUTE, {
           params: {
             search,
             size: size || INITIAL_NUMBER,
-            from_created: start_date && new Date(start_date as string).getTime() / 1000,
-            to_created: end_date && new Date(end_date as string).getTime() / 1000,
+            from_created: start_date && new Date(String(start_date).replace(/-/g, '/')).getTime() / 1000,
+            to_created: end_date && (new Date(String(end_date).replace(/-/g, '/')).getTime() / 1000),
           },
         })
       ).data.data.entries as NewsItem[];
+      
+
+      // incosistent behaviour with different date ranges
+
       // TODO https://github.com/eternagame/eternagame.org/issues/157 move filtering to backend
       switch (sort) {
         case 'news':

--- a/src/views/news/NewsExplore/NewsExplore.vue
+++ b/src/views/news/NewsExplore/NewsExplore.vue
@@ -18,7 +18,7 @@
         replace
         :isInSidebar="isInSidebar"
       />
-      <CalendarPanel  v-if="isInSidebar" @page-update="monthFetch" :notableDates="calendarItems" :isInSidebar="isInSidebar"/>
+      <CalendarPanel @page-update="monthFetch" :notableDates="calendarItems" :isInSidebar="isInSidebar"/>
       <!-- <TagsPanel :tags="tags" :isInSidebar="isInSidebar" /> -->
     </template>
     <template #mobileSearchbar>
@@ -72,14 +72,9 @@
 
     private newsItems: (NewsItem|BlogItem)[] = [];
 
-    private calendarItems:{} = {};
+    private calendarItems:{selectAttribute: { dot: string; dates: string; }[]} = {selectAttribute: []} ;
 
-    private defaultDate!: DateItem;
-
-    async monthFetch(monthData = this.defaultDate){
-
-      let i = 0;
-      const totalDates = [];
+    async monthFetch(monthData: DateItem){
 
       const res = (
           await this.$http.get(ROUTE, {
@@ -92,21 +87,11 @@
           ).data.data.entries as NewsItem[];
       
       // Timezone in UTC, calendar dates parsing is incorrect
-      
-      for(; i < res.length; i += 1){
 
-        totalDates.push(
-          {
-            dot: 'blue',
-            dates: new Date(Number(res[i].timestamp) * 1000).toLocaleString('en-US', {timeZone: 'UTC'}),
-          }
-        );
-      }
-
-
-      this.calendarItems = {
-        selectAttribute: totalDates,
-        };
+      this.calendarItems.selectAttribute = res.map((element) =>({
+              dot: 'blue',
+              dates: new Date(Number(element.timestamp) * 1000).toLocaleString('en-US', {timeZone: 'UTC'}),
+        }));
     }
 
     async fetch() {


### PR DESCRIPTION
News tab calendar now highlights dates when things were posted, and the range of the calendar now functions.
![image](https://user-images.githubusercontent.com/80924593/121729769-d455fe80-cabc-11eb-94e6-6054de22ed08.png)

Without Range Highlight
![image](https://user-images.githubusercontent.com/80924593/121729838-e768ce80-cabc-11eb-92c3-1ec5b1d230d6.png)
