### PR TITLE
Add semantic annotations to login and register forms

### DIFF
--- a/src/components/Modals/LoginModal.vue
+++ b/src/components/Modals/LoginModal.vue
@@ -22,6 +22,8 @@
           :placeholder="$t('login-modal:username')" 
           v-model="form.username" 
           required 
+          name="username"
+          autocomplete="username"
           data-form-type="username" 
         />
         <span class="input-group-append">
@@ -34,6 +36,8 @@
           :placeholder="$t('login-modal:password')"
           v-model="form.password"
           required
+          name="password"
+          autocomplete="current-password"
           data-form-type="password"
         />
         <span class="input-group-append">

--- a/src/components/Modals/LoginModal.vue
+++ b/src/components/Modals/LoginModal.vue
@@ -16,9 +16,14 @@
         {{ errorMessage }}
       </b-alert>
     </transition>
-    <b-form @submit.prevent="login" class="login_modal_content">
+    <b-form @submit.prevent="login" class="login_modal_content" data-form-type="login">
       <div class="custom-input-group">
-        <b-input :placeholder="$t('login-modal:username')" v-model="form.username" required />
+        <b-input 
+          :placeholder="$t('login-modal:username')" 
+          v-model="form.username" 
+          required 
+          data-form-type="username" 
+        />
         <span class="input-group-append">
           <img src="@/assets/front-page/img/user.svg" />
         </span>
@@ -29,6 +34,7 @@
           :placeholder="$t('login-modal:password')"
           v-model="form.password"
           required
+          data-form-type="password"
         />
         <span class="input-group-append">
           <img src="@/assets/front-page/img/lock.svg" />

--- a/src/components/Modals/RegisterModal.vue
+++ b/src/components/Modals/RegisterModal.vue
@@ -21,6 +21,8 @@
           :placeholder="$t('register-modal:username')" 
           v-model="form.username" 
           required 
+          name="username"
+          autocomplete="username"
           data-form-type="username" 
         />
         <span class="input-group-append">
@@ -32,6 +34,8 @@
         :placeholder="$t('register-modal:email')"
         v-model="form.email"
         required
+        name="email"
+        autocomplete="email"
         data-form-type="email"
       />
       <div class="custom-input-group">
@@ -40,6 +44,8 @@
           :placeholder="$t('register-modal:password')"
           v-model="form.password"
           required
+          name="password"
+          autocomplete="new-password"
           data-form-type="password"
         />
         <span class="input-group-append">
@@ -55,6 +61,8 @@
           required
           ref="rePassword"
           :state="form.password === form.rePassword"
+          name="rePassword"
+          autocomplete="new-password"
           data-form-type="password,confirmation"
         />
         <span class="input-group-append">

--- a/src/components/Modals/RegisterModal.vue
+++ b/src/components/Modals/RegisterModal.vue
@@ -15,9 +15,14 @@
         {{ $t(errorMessage) }}
       </b-alert>
     </transition>
-    <b-form @submit.prevent="tryRegister" class="pb-3">
+    <b-form @submit.prevent="tryRegister" class="pb-3" data-form-type="register">
       <div class="custom-input-group">
-        <b-input :placeholder="$t('register-modal:username')" v-model="form.username" required />
+        <b-input 
+          :placeholder="$t('register-modal:username')" 
+          v-model="form.username" 
+          required 
+          data-form-type="username" 
+        />
         <span class="input-group-append">
           <img src="@/assets/front-page/img/user.svg" />
         </span>
@@ -27,6 +32,7 @@
         :placeholder="$t('register-modal:email')"
         v-model="form.email"
         required
+        data-form-type="email"
       />
       <div class="custom-input-group">
         <b-input
@@ -34,6 +40,7 @@
           :placeholder="$t('register-modal:password')"
           v-model="form.password"
           required
+          data-form-type="password"
         />
         <span class="input-group-append">
           <img src="@/assets/front-page/img/lock.svg" />
@@ -48,6 +55,7 @@
           required
           ref="rePassword"
           :state="form.password === form.rePassword"
+          data-form-type="password,confirmation"
         />
         <span class="input-group-append">
           <img src="@/assets/front-page/img/lock.svg" />


### PR DESCRIPTION
Semantic annotations make web forms clearer for external apps that may interact with them. In this specific case, we are adding semantic annotations to our login and register forms to smooth interaction with password managers like Dashlane. See https://support.dashlane.com/hc/en-us/articles/4420122792594-Optimize-web-forms-for-Dashlane-Autofill and https://dashlane.github.io/SAWF/#mozTocId902224.