### PR TITLE
Limit number of events displayed on homepage calendar

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
     'no-unused-vars': 'off',
     'arrow-parens': 'off',
     'object-curly-newline': 'off',
-    'no-underscore-dangle': ['error', { allow: ['__INITIAL_STATE__'] }],
+    'no-underscore-dangle': ['error', { allow: ['__INITIAL_STATE__', '_instance'] }],
     // Why doesn't typescript-eslint do this for us? No idea!
     "no-use-before-define": "off",
     "no-shadow": "off",

--- a/src/views/home/PlayerHome/PlayerHome.vue
+++ b/src/views/home/PlayerHome/PlayerHome.vue
@@ -42,7 +42,7 @@
 
           <div class="col-md-6">
             <h3>Upcoming Events</h3>
-            <FullCalendar :options="calendarOptions" />
+            <FullCalendar @hook:mounted="filterEvents" ref="fullCalendar" :options="calendarOptions" />
             <p class="text-right"><a href="/calendar">View All ></a></p>
           </div>
         </div>
@@ -191,8 +191,7 @@
           views: {
             upcoming: {
               type: 'list',
-              duration: { days: 3 },
-              listDayAltFormat: 'dddd',
+              duration: { days: 14 },
             },
           },
           height: 'auto',
@@ -203,6 +202,22 @@
           },
         },
       };
+    }
+
+    filterEvents() {
+      // This function is called after the FullCal component has mounted and the calendar
+      // is available (via hook:mounted; see https://github.com/vuejs/core/issues/3178). 
+      // We get the events the calendar is displaying, sort them, and then we remove all 
+      // events past the number we want to display. 
+      // This method is necessary because FullCalendar's Google Calendar integration
+      // doesn't provide parameters for maxResults (to limit returned events) or 
+      // orderBy (to sort).
+      const fcAPI = this.$refs?.fullCalendar?.getApi();
+      const numberOfEventsToDisplay = 4;
+      const eventsToRemove = fcAPI.getEvents()
+        .sort((a, b) => a._instance.range.end > b._instance.range.end)
+        .slice(numberOfEventsToDisplay)
+        .map(event => event.remove());
     }
 
     handleEventClick(info: {


### PR DESCRIPTION
We only want to display the upcoming n events in our homepage event list. FullCalendar is rather limited in this area of its API. The Google Calendar API supports a maxResults parameter, but FullCalendar hardcodesthis value. To get around this, we fetch events for the next two weeks, then use FullCalendar's event API to remove all but the first n events. This is complicated by the FullCalendar Vue component. The component makes the FullCalendar object available via ref, but the ref is undefined in the parent component mounted hook (perhaps as a result of the way the FullCalendar Vue component instantiates itself) and doesn't emit any ready events. Instead, we use the non-public Vue "hook:mounted", which allows us to listen for the FullCalendar component mount in the parent PlayerHome component. 

I have to merge into dev to test the fix with the Google Calendar integration, because our calendar currently disallows requests from localhost. Need to change the referrers policy to allow it once I have developer console access.