### PR TITLE
Improve notifications

### DIFF
--- a/src/components/PageLayout/Navbar/Icons/NavbarIcon.vue
+++ b/src/components/PageLayout/Navbar/Icons/NavbarIcon.vue
@@ -6,8 +6,8 @@
     variant="link"
     toggle-class="px-0 text-decoration-none"
     no-caret
-    @show="onShow"
-    @hide="onHide"
+    @show="$emit('shown', true)"
+    @hide="$emit('shown', false)"
   >
     <template #button-content>
       <div>
@@ -31,16 +31,6 @@
     components: {},
   })
   export default class NavbarIcon extends Vue {
-    public isShown = false;
-
-    onShow() {
-      this.isShown = true;
-      this.$emit('shown');
-    }
-
-    onHide() {
-      this.isShown = false;
-    }
   }
 </script>
 

--- a/src/components/PageLayout/Navbar/Icons/NavbarIcon.vue
+++ b/src/components/PageLayout/Navbar/Icons/NavbarIcon.vue
@@ -7,6 +7,7 @@
     toggle-class="px-0 text-decoration-none"
     no-caret
     @show="onShow"
+    @hide="onHide"
   >
     <template #button-content>
       <div>
@@ -30,8 +31,15 @@
     components: {},
   })
   export default class NavbarIcon extends Vue {
+    public isShown = false;
+
     onShow() {
+      this.isShown = true;
       this.$emit('shown');
+    }
+
+    onHide() {
+      this.isShown = false;
     }
   }
 </script>

--- a/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
+++ b/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
@@ -182,6 +182,10 @@
     font-size: 16px;
     font-weight: bold;
     margin-top: 14.5px;
+
+    @include media-breakpoint-down(md) {
+      font-size: 13px;
+    }
   }
 
   .border {
@@ -213,5 +217,10 @@
     width: 25px;
     height: 25px;
     align-self: center;
+
+    @include media-breakpoint-down(md) {
+      width: 18px;
+      height: 18px;
+    }
   }
 </style>

--- a/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
+++ b/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
@@ -7,7 +7,7 @@
       </div>
     </template>
     <template #text>{{ $t('nav-bar:notifications') }}</template>
-    <template>
+    <template v-slot="slotProp">
       <div class="activity-container">
         <div class="d-flex justify-content-between">
           <div style="display: flex;">
@@ -31,7 +31,7 @@
       </div>
       <div class="border"></div>
       <router-link to="/feed" style="color:white">
-        <div class="view-all-link">
+        <div class="view-all-link" @click="slotProp.hideDropdown.hide()">
           {{ $t('nav-bar:notifications-view-all') }}
         </div>
       </router-link>

--- a/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
+++ b/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
@@ -93,7 +93,8 @@
     async fetch() {
       const res = await this.$http.get(NUM_NOTIFICATIONS_ROUTE);
       this.notificationsCount = res.data.data.noti_count;
-      if (res.data.data.noti_count > this.notificationsCount || !this.fetchState.firstFetchComplete) {
+
+      if (this.notificationsCount > 0 || !this.fetchState.firstFetchComplete) {
         await this.updateDropdownContents();
       }
     }

--- a/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
+++ b/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
@@ -101,14 +101,14 @@
       this.notificationsCount = res.data.data.noti_count;
 
       if (this.notificationsCount > 0 || !this.fetchState.firstFetchComplete) {
+        this.isFetching = true;
+        await this.updateDropdownContents();
+        this.isFetching = false;
+
         if ((this.$refs.dropdown as NavbarIcon).isShown) {
           this.notificationsCount = 0;
           await this.$http.post('/post/', new URLSearchParams({ type: 'notification_read' }));
         }
-
-        this.isFetching = true;
-        await this.updateDropdownContents();
-        this.isFetching = false;
       }
     }
 
@@ -160,6 +160,7 @@
     private isReward(notification: NotificationItem) {
       return notification.type === NotificationType.REWARD;
     }
+
   }
 </script>
 

--- a/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
+++ b/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
@@ -10,7 +10,12 @@
     <template>
       <div class="activity-container">
         <div class="d-flex justify-content-between">
-          <h1 class="header">{{ $t('nav-bar:notifications-title') }}</h1>
+          <div style="display: flex;">
+            <h1 class="header">{{ $t('nav-bar:notifications-title') }}</h1>
+            <div v-if="isFetching" class="fetch-loader">
+              <SimpleLoader />
+            </div>
+          </div>
         </div>
         <div class="border"></div>
         <template v-for="item in notifications">
@@ -49,6 +54,7 @@
   import CommentNotification from './CommentNotification.vue';
   import GroupNotificationItem from './GroupNotification.vue';
   import RewardNotificationItem from './RewardNotification.vue';
+  import SimpleLoader from '../../../SimpleLoader.vue';
 
   const NUM_NOTIFICATIONS_ROUTE = '/get/?type=noti_count_for_user';
 
@@ -65,13 +71,14 @@
       PrivateMessageNotification,
       CommentNotification,
       GroupNotificationItem,
-      RewardNotificationItem
+      RewardNotificationItem,
+      SimpleLoader
     },
   })
   export default class NotificationIcon extends Mixins(FetchMixin) {
     private notificationsCount = 0;
 
-    private calledFetch = false;
+    private isFetching = false;
 
     private notifications: NotificationItem[] = [];
 
@@ -95,7 +102,9 @@
       this.notificationsCount = res.data.data.noti_count;
 
       if (this.notificationsCount > 0 || !this.fetchState.firstFetchComplete) {
+        this.isFetching = true;
         await this.updateDropdownContents();
+        this.isFetching = false;
       }
     }
 
@@ -193,5 +202,12 @@
         background-color: var(--primary);
       }
     }
+  }
+
+  .fetch-loader {
+    margin: 0 10px;
+    width: 25px;
+    height: 25px;
+    align-self: center;
   }
 </style>

--- a/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
+++ b/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <NavbarIcon ref="dropdown" @shown="onShown">
+  <NavbarIcon @shown="onShown">
     <template #icon>
       <div class="d-inline-block">
         <div class="unread" v-if="notificationsCount > 0"></div>
@@ -78,6 +78,8 @@
   export default class NotificationIcon extends Mixins(FetchMixin) {
     private notificationsCount = 0;
 
+    private isDropdownShown = false;
+
     private isFetching = false;
 
     private notifications: NotificationItem[] = [];
@@ -92,7 +94,8 @@
       clearInterval(this.checkDataInterval);
     }
 
-    async onShown() {
+    async onShown(isShown: boolean) {
+      this.isDropdownShown = isShown;
       await this.$fetch();
     }
 
@@ -105,7 +108,7 @@
         await this.updateDropdownContents();
         this.isFetching = false;
 
-        if ((this.$refs.dropdown as NavbarIcon).isShown) {
+        if (this.isDropdownShown) {
           this.notificationsCount = 0;
           await this.$http.post('/post/', new URLSearchParams({ type: 'notification_read' }));
         }

--- a/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
+++ b/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <NavbarIcon @shown="onShown">
+  <NavbarIcon ref="dropdown" @shown="onShown">
     <template #icon>
       <div class="d-inline-block">
         <div class="unread" v-if="notificationsCount > 0"></div>
@@ -93,7 +93,6 @@
     }
 
     async onShown() {
-      await this.$http.post('/post/', new URLSearchParams({ type: 'notification_read' }));
       await this.$fetch();
     }
 
@@ -102,6 +101,11 @@
       this.notificationsCount = res.data.data.noti_count;
 
       if (this.notificationsCount > 0 || !this.fetchState.firstFetchComplete) {
+        if ((this.$refs.dropdown as NavbarIcon).isShown) {
+          this.notificationsCount = 0;
+          await this.$http.post('/post/', new URLSearchParams({ type: 'notification_read' }));
+        }
+
         this.isFetching = true;
         await this.updateDropdownContents();
         this.isFetching = false;

--- a/src/components/PageLayout/SimpleLoader.vue
+++ b/src/components/PageLayout/SimpleLoader.vue
@@ -1,5 +1,5 @@
 <template>
-  <span class="loader"></span>
+  <span class="loader" aria-label="Loading"></span>
 </template>
 
 <style lang="scss" scoped>

--- a/src/components/PageLayout/SimpleLoader.vue
+++ b/src/components/PageLayout/SimpleLoader.vue
@@ -1,0 +1,25 @@
+<template>
+  <span class="loader"></span>
+</template>
+
+<style lang="scss" scoped>
+.loader {
+  width: 100%;
+  height: 100%;
+  border: 5px solid #FFF;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+} 
+</style>


### PR DESCRIPTION
Various small fixes and enhancements:

- Automatically fetch new notifications from `NEWS_FEED_ROUTE` if `NUM_NOTIFICATIONS_ROUTE` returns notification count > 0. Previously it would only fetch the new notification on page load. The bug was introduced [here](https://github.com/eternagame/eternagame.org/commit/19ce3fab61c44a543393e4a2ad7e17d6647a8967#diff-f0945c4082cb1a325808875451d0a880945e312994a2eaf9aa4bcc995b7a7792).
- Show a loader while we are fetching notifications. Fixes #143 
Desktop:
![Screenshot from 2022-07-20 18-13-48](https://user-images.githubusercontent.com/22116610/180033757-11a914b9-fb81-49cb-b994-2da738cadc04.png)
Mobile:
![Screenshot from 2022-07-20 18-47-52](https://user-images.githubusercontent.com/22116610/180038593-d3d42b53-0153-41f1-a3b4-0ebf7349e06b.png)

 - The red dot indicator now disappears when the user opens the notification dropdown and it does not even appear if new notifications are fetched while the dropdown is open.
 