### PR TITLE
"View all" text in notifications dropdown

### DIFF
--- a/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
+++ b/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
@@ -7,17 +7,10 @@
       </div>
     </template>
     <template #text>{{ $t('nav-bar:notifications') }}</template>
-    <template v-slot="slotProp">
+    <template>
       <div class="activity-container">
         <div class="d-flex justify-content-between">
           <h1 class="header">{{ $t('nav-bar:notifications-title') }}</h1>
-          <router-link to="/feed">
-            <img
-              class="mt-2"
-              src="@/assets/navbar/popOut.svg"
-              @click="slotProp.hideDropdown.hide()"
-            />
-          </router-link>
         </div>
         <div class="border"></div>
         <template v-for="item in notifications">

--- a/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
+++ b/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
@@ -23,10 +23,13 @@
         <b-dropdown-item v-if="notifications.length == 0">
           {{$t('activity-feed:empty')}}
         </b-dropdown-item>
-        <b-dropdown-item href="/feed">
-          {{ $t('nav-bar:notifications-view-all') }}
-        </b-dropdown-item>
       </div>
+      <div class="border"></div>
+      <router-link to="/feed" style="color:white">
+        <div class="view-all-link">
+          {{ $t('nav-bar:notifications-view-all') }}
+        </div>
+      </router-link>
     </template>
   </NavbarIcon>
 </template>
@@ -149,7 +152,7 @@
 <style lang="scss" scoped>
   @import '@/styles/global.scss';
 
-  ::v-deep a {
+  ::v-deep a.dropdown-item {
     padding-right: 10px !important;
     padding-left: 10px !important;
     border-radius: 3px;
@@ -175,5 +178,19 @@
   img.icon {
     width: 24px;
     height: 24px;
+  }
+
+  .view-all-link {
+    padding: 10px;
+    text-align: center;
+    color: white !important;
+
+    &:hover, &:focus {
+      background-color: #212529;
+
+      @include media-breakpoint-down(md) {
+        background-color: var(--primary);
+      }
+    }
   }
 </style>

--- a/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
+++ b/src/components/PageLayout/Navbar/Icons/NotificationIcon/NotificationIcon.vue
@@ -30,6 +30,9 @@
         <b-dropdown-item v-if="notifications.length == 0">
           {{$t('activity-feed:empty')}}
         </b-dropdown-item>
+        <b-dropdown-item href="/feed">
+          {{ $t('nav-bar:notifications-view-all') }}
+        </b-dropdown-item>
       </div>
     </template>
   </NavbarIcon>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -308,6 +308,7 @@
   "nav-bar:terms": "terms",
   "nav-bar:code-of-conduct": "code of conduct",
   "nav-bar:notifications-title": "Latest Activity",
+  "nav-bar:notifications-view-all": "View all",
   "nav-bar:external-link": "External link",
   "nav-bar:eternacon": "Eternacon",
   "nav-bar:merch": "Merchandise",


### PR DESCRIPTION
Adds the "View all" link under notifications. It also removes the pop-out icon, because it is confusing to have two buttons that do the same thing in the same dropdown.

Fixes #144
![Screenshot from 2022-07-20 19-24-11](https://user-images.githubusercontent.com/22116610/180046931-93ca8094-c52b-4752-b7a3-4dd736e6ce11.png)
![Screenshot from 2022-07-20 19-23-23](https://user-images.githubusercontent.com/22116610/180046935-283417c5-4fbc-406a-83b5-292bd904bd0f.png)
 