### PR TITLE
Add button linking pseudoknot training collection to lab carousel slide

### DIFF
--- a/src/views/home/PlayerHome/components/banner/LabSlide.vue
+++ b/src/views/home/PlayerHome/components/banner/LabSlide.vue
@@ -13,6 +13,9 @@
         <b-button variant="primary" class="enter-lab" size="lg" :to="`/labs/${nid}`">
           {{ $t('home-banner:enter') }}
         </b-button>
+        <b-button v-if="nid === '11311397'" variant="primary" class="training-button" size="lg" :to="`/collections/11366215`">
+          Lab Training
+        </b-button>
       </div>
       <div class="banner-status">
         <div class="countdown" v-if="project_closes">
@@ -224,5 +227,9 @@
   ::v-deep .flip-clock__slot {
     font-size: .6rem !important;
     font-weight: bold;
+  }
+
+  .training-button {
+    margin-left: 1rem;
   }
 </style>


### PR DESCRIPTION
The API response for labs doesn't include any options for specifying training collections, so until we add a feature for something like that, I've hardcoded a training collection button into the lab slide that directly links to the correct collection. It will only display for the pseudoknot lab now, but in the future we may want to add more options for associating training collections with a given lab.