### PR TITLE
Add watcher to retrigger project data fetch on user login

### DIFF
--- a/src/views/labs/LabView/LabView.vue
+++ b/src/views/labs/LabView/LabView.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script lang="ts">
-  import { Component, Mixins } from 'vue-property-decorator';
+  import { Component, Mixins, Watch } from 'vue-property-decorator';
   import { CommentItem } from '@/types/common-types';
   import EternaPage from '@/components/PageLayout/EternaPage.vue';
   import Comments from '@/components/PageLayout/Comments.vue';
@@ -100,6 +100,9 @@
     get openRounds() {
       return this.lab?.puzzles.filter(round => !this.roundClosed(round)) || [];
     }
+
+    @Watch('$vxm.user.loggedIn')
+    fetchOnUserLogin() { this.$fetch(); }
   }
 </script>
 


### PR DESCRIPTION
## Summary
The lab page was incorrectly displaying the user submissions after a user had logged in (see issue #359). 

## Implementation Notes
This fix retriggers the project data fetch when the user store's logged in state changes. This is necessary because after the user logs in, we need to fetch the number of submitted solutions for this user now that we have their uid.

## Testing
Verified fix on local dev server.

## Related Issues
Closes #359.
