### PR TITLE
fix: Remove COVID-19 training puzzle link from POTW slide

### DIFF
--- a/src/views/home/PlayerHome/components/banner/POTWSlide.vue
+++ b/src/views/home/PlayerHome/components/banner/POTWSlide.vue
@@ -20,11 +20,6 @@
           <i class="arrow_right"></i>{{ $t('puzzle-slide:past-potw') }}
         </p>
       </router-link>
-      <router-link to="/puzzles/?search=:COVID19" class="link d-none d-sm-block">
-        <p style="margin-right: 20px;color:white;font-weight:bold;font-size:14px">
-          <i class="arrow_right"></i>{{ $t('puzzle-slide:past-training') }}
-        </p>
-      </router-link>
     </div>
   </b-carousel-slide>
 </template>


### PR DESCRIPTION
## Summary
The COVID-19 training puzzle link is no longer relevant. 

## Implementation Notes
Removed link from the POTW component.

## Testing
The link is no longer on the POTW slide.

## Related Issues
Clses #107.
