### PR TITLE
Segment Lab Explore gallery by experimental phase

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -359,6 +359,7 @@
   "lab-card:status-3": "Synthesizing RNA",
   "lab-card:status-4": "Getting Data",
   "lab-card:status-5": "Results Posted",
+  "lab-card:status-6": "Archived",
   "page:comments-title": "Discussion",
   "page:comments-action": "Comment",
   "page:comments-enter": "Enter your comments here.",

--- a/src/views/labs/LabsExplore/LabsExplore.vue
+++ b/src/views/labs/LabsExplore/LabsExplore.vue
@@ -1,9 +1,14 @@
 <template>
   <EternaPage :title="$t('nav-bar:labs')">
     <Paginator :loading="fetchState.pending" :total="total" :defaultIncrement="increment" @load="$fetch">
-      <Gallery setCur>
-        <LabCard v-for="lab in labs" :key="lab.nid" :lab="lab" />
-      </Gallery>
+      <section class="phase-section" v-for="phase in Object.keys(segmentedLabs)" :key="phase">
+        <h3 class="phase-title" v-b-toggle="`collapse-${phase}`">{{ getPhaseTitle(phase) }}</h3>
+        <b-collapse :id="`collapse-${phase}`" :visible="phase == '1'" class="mt-2">
+          <Gallery setCur>
+            <LabCard v-for="lab in segmentedLabs[phase]" :key="lab.nid" :lab="lab" />
+          </Gallery>
+        </b-collapse>
+      </section>
     </Paginator>
     <template #sidebar="{ isInSidebar }">
       <SearchPanel v-if="isInSidebar" :placeholder="$t('search:labs')" :isInSidebar="isInSidebar" />
@@ -92,5 +97,45 @@
       }
       this.total = +res.num_labs;
     }
+
+    get segmentedLabs(): Record<string, LabCardData[] | []> {
+      const segmentedLabs: Record<string, LabCardData[] | []> = {
+        "1": [],
+        "2": [],
+        "3": [],
+        "4": [],
+        "5": [],
+        "6": [],
+      };
+        
+      this.labs.map((lab) => {
+        // If the lab is older than 2 years old, add to archived labs
+        if (new Date(lab.created).getTime() < (new Date().getTime() - (2 * 365 * 24 * 60 * 60 * 1000))) {
+          segmentedLabs["6"] = [...segmentedLabs["6"], lab];
+        } else if (lab.exp_phase) {
+          // If the lab is less than 2 years old, add to the appropriate phase
+          segmentedLabs[lab.exp_phase] = [...segmentedLabs[lab.exp_phase], lab];
+        } else {
+          // If the lab doesn't have an experimental phase, add to archived labs
+          segmentedLabs["6"] = [...segmentedLabs["6"], lab];
+        }
+        return 0;
+      });
+
+      return segmentedLabs;
+    }
+
+    getPhaseTitle(phase: string) {
+      return this.$t(`lab-card:status-${phase}`);
+    }
   }
 </script>
+
+<style>
+  .phase-section {
+    margin-top: 1rem;
+  }
+  .phase-title {
+    font-size: 1.5rem;
+  }
+</style>


### PR DESCRIPTION
## Summary
This makes the lab page easier to understand, highlighting the labs that are currently accepting submissions and giving context for other labs based on their phase in the experimental pipeline. 

## Implementation Notes
The LabExplore page now uses a computed property to segment the labs by experimental phase, and displays the lab cards in collapsible sections. Any lab without an experimental phase or that is older than 2 years (just a suggested timescale, can easily adjust) is placed into an "Archived" section, as some old labs are paused at various stages of the experimental pipeline.

## Testing
Visually verified on local environment.

## Related Issues
Closes #94.
