### PR TITLE
Update puzzle and script view usernames to link to player profile

### DIFF
--- a/src/components/PageLayout/Comment.vue
+++ b/src/components/PageLayout/Comment.vue
@@ -5,8 +5,8 @@
       <router-link :to="`/players/${uid}`">
         <p class="commenter-name mb-0">
           {{ name }}
-        </p></router-link
-      >
+        </p>
+      </router-link>
       <p style="font-size: 0.6rem">{{ created }}</p>
       <p v-dompurify-html="comment" style="overflow-wrap: break-word;">{{ comment }}</p>
       <button @click="deleteComment()" v-if="canDelete" style="cursor:pointer" class="btn btn-danger btn-sm" :disabled="deleting">

--- a/src/views/puzzles/PuzzleView/PuzzleView.vue
+++ b/src/views/puzzles/PuzzleView/PuzzleView.vue
@@ -44,7 +44,9 @@
         </template>
         <ul style="padding: 0; list-style-type:none" v-if="puzzle">
           <li v-if="madeByPlayer">
-            <img :src="avatar" alt="author" class="icon" />{{ puzzle.username }}
+            <router-link :to="`/players/${puzzle.uid}`">
+              <img :src="avatar" alt="author" class="icon" />{{ puzzle.username }}
+            </router-link>
           </li>
           <li v-if="puzzle.folder">
             <img src="@/assets/chemical_bond.svg" alt="folding engine" class="icon" />{{ puzzle.folder }}

--- a/src/views/scripts/ScriptView/ScriptView.vue
+++ b/src/views/scripts/ScriptView/ScriptView.vue
@@ -40,7 +40,9 @@
         </template>
         <ul style="padding: 0; list-style-type:none" v-if="script">
           <li>
-            <img :src="avatar" alt="author" class="icon" />{{ script.author.name }}<span v-b-tooltip.hover title="Trusted author" v-if="script.is_trusted === '1'">&nbsp;✔</span>
+            <router-link :to="`/players/${script.uid}`">
+              <img :src="avatar" alt="author" class="icon" />{{ script.author.name }}<span v-b-tooltip.hover title="Trusted author" v-if="script.is_trusted === '1'">&nbsp;✔</span>
+            </router-link>
           </li>
           <li>{{ script.type }}</li>
           <li v-if="isAuthor">{{ script.is_private === '1' ? 'Private' : 'Public' }}</li>


### PR DESCRIPTION
## Summary
The usernames in puzzle and script view components sidebar panels now link to the player's profile. This lets people easily find more puzzles or scripts by the same authors, and matches the behavior of usernames in comments. 

## Implementation Notes
Add router-links to player profiles to match how we handle the username in comments.

## Testing
Visually and behaviorally verified on local dev environment.

## Related Issues
Closes #366.
