### PR TITLE
Change background-attachment for hero fallback image

### DIFF
--- a/src/views/home/LandingPage/components/HeroSection.vue
+++ b/src/views/home/LandingPage/components/HeroSection.vue
@@ -54,7 +54,7 @@
   @import '@/styles/global.scss';
 
   .video {
-    background: url(~@/assets/front-page/video/bg_video.jpg) no-repeat center center fixed;
+    background: url(~@/assets/front-page/video/bg_video.jpg) no-repeat center center scroll;
     -webkit-background-size: cover;
     -moz-background-size: cover;
     -o-background-size: cover;


### PR DESCRIPTION
## Summary
`background-attachment: fixed` plus `background-size: cover` has unpredictable behavior on mobile (seen on iOS Safari). Namely, `background-attachment: fixed` fixes the image relative to the viewport. `background-size: cover`, then, scales the image height to fit the viewport, which is very large in mobile devices. 

## Implementation Notes
To avoid this scaling issue, we're changing the attachment to scroll. We lose the parallax effect, but the image is largely hidden by the hero content anyway, and this change will only impact mobile (the hero video is used on larger screens).

## Testing
Tested live on iPhone with Safari debugger. 
